### PR TITLE
Add test51.json pipeline to filter factbook data by Area < 300

### DIFF
--- a/config/test51.json
+++ b/config/test51.json
@@ -1,0 +1,37 @@
+{
+  "component": [
+    {
+      "id": "Input_CSV1",
+      "component_name": "Input_CSV1",
+      "component_type": "INPUTFILE",
+      "input_data_file_type": "CSV",
+      "input_data_file_path": "../data/factbook.csv",
+      "input_schema_file_path": "",
+      "delimiter": ",",
+      "header": "true",
+      "table_name": "",
+      "database_name": ""
+    },
+    {
+      "id": "Filter_1",
+      "component_name": "Filter_1",
+      "component_type": "Filter",
+      "filter_criteria": [
+        "Area < 300"
+      ],
+      "node_reference": [
+        "Input_CSV1"
+      ]
+    },
+    {
+      "id": "Output_1",
+      "component_name": "Output_1",
+      "component_type": "OUTPUTFILE",
+      "output_data_file_type": "CSV",
+      "output_data_file_path": "../outputfile/factbook300",
+      "node_reference": [
+        "Filter_1"
+      ]
+    }
+  ]
+}

--- a/etl/run_pipeline.py
+++ b/etl/run_pipeline.py
@@ -17,7 +17,7 @@ from src.etl.SparkDriver import DriverProgram
 
 def main(json_path=None):
     if not json_path:
-        json_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '../config/local_test3.json'))
+        json_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '../config/test51.json'))
 
     json_path = os.path.normpath(json_path)
     print(f"Using JSON config: {json_path}")


### PR DESCRIPTION
# Add test51.json pipeline to filter factbook data by Area < 300

## Summary
Created a new ETL pipeline configuration `test51.json` that reads the factbook dataset, filters records where Area < 300, and outputs the results to the factbook300 directory. Also updated `run_pipeline.py` to default to this new pipeline configuration.

**Changes:**
- **Added `config/test51.json`**: New pipeline with Input → Filter → Output flow
  - Reads `factbook.csv` from data directory 
  - Applies filter condition `Area < 300`
  - Outputs to `outputfile/factbook300`
- **Modified `etl/run_pipeline.py`**: Changed default pipeline from `local_test3.json` to `test51.json`

## Review & Testing Checklist for Human
⚠️ **Important: These changes are untested due to local environment setup issues**

- [ ] **Run the pipeline end-to-end**: Execute `python etl/run_pipeline.py` and verify it completes without errors
- [ ] **Verify filter logic**: Check that output in `outputfile/factbook300/` contains only countries with Area < 300
- [ ] **Confirm output directory creation**: Ensure the pipeline creates the factbook300 directory automatically
- [ ] **Test filter syntax**: Verify that `"Area < 300"` is valid syntax for the PySpark filtering engine
- [ ] **Check for breaking changes**: Ensure changing the default pipeline doesn't disrupt existing workflows that depend on `local_test3.json`

### Recommended Test Plan
1. Run `cd /path/to/devinpoc && python etl/run_pipeline.py`
2. Check that `outputfile/factbook300/` directory is created with filtered CSV output
3. Sample a few output records to confirm Area values are all < 300
4. Compare input row count vs output row count for reasonableness
5. Test running with explicit JSON: `python etl/run_pipeline.py config/local_test3.json` to ensure old pipelines still work

### Notes
- Pipeline configuration follows the same JSON structure pattern as existing pipelines (test1.json, local_test3.json)
- Filter condition syntax matches the format used in test1.json (`"Area < 200"`)
- Uses relative paths compatible with Linux environment (`../data/`, `../outputfile/`)

---
**Link to Devin run**: https://app.devin.ai/sessions/a667b8d8dbf84175ba040b8f3c83d370  
**Requested by**: parvez.shaikh@ltimindtree.com (@ltibfspoc)