### PR TITLE
Add test51.json pipeline to filter factbook data by Area < 300

### DIFF
--- a/src/config/test51.json
+++ b/src/config/test51.json
@@ -1,0 +1,37 @@
+{
+  "component": [
+    {
+      "id": "Input_CSV1",
+      "component_name": "Input_CSV1",
+      "component_type": "INPUTFILE",
+      "input_data_file_type": "CSV",
+      "input_data_file_path": "../data/factbook.csv",
+      "input_schema_file_path": "",
+      "delimiter": ",",
+      "header": "true",
+      "table_name": "",
+      "database_name": ""
+    },
+    {
+      "id": "Filter_1",
+      "component_name": "Filter_1",
+      "component_type": "Filter",
+      "filter_criteria": [
+        "Area < 300"
+      ],
+      "node_reference": [
+        "Input_CSV1"
+      ]
+    },
+    {
+      "id": "Output_1",
+      "component_name": "Output_1",
+      "component_type": "OUTPUTFILE",
+      "output_data_file_type": "CSV",
+      "output_data_file_path": "../outputfile/factbook300",
+      "node_reference": [
+        "Filter_1"
+      ]
+    }
+  ]
+}

--- a/src/etl/run_pipeline.py
+++ b/src/etl/run_pipeline.py
@@ -17,7 +17,7 @@ from src.etl.SparkDriver import DriverProgram
 
 def main(json_path=None):
     if not json_path:
-        json_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '../config/local_test3.json'))
+        json_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '../config/test51.json'))
 
     json_path = os.path.normpath(json_path)
     print(f"Using JSON config: {json_path}")


### PR DESCRIPTION
# Add test51.json pipeline to filter factbook data by Area < 300

## Summary
This PR implements a new PySpark ETL pipeline configuration that filters factbook data to only include countries/territories with Area < 300. The changes include:

1. **New Pipeline Configuration** (`src/config/test51.json`): 3-component pipeline with Input → Filter → Output flow
2. **Default Pipeline Change** (`src/etl/run_pipeline.py`): Updated default from `local_test3.json` to `test51.json`

The pipeline reads from `data/factbook.csv`, applies the Area filter condition, and outputs results to `outputfile/factbook300/`. Local testing showed successful filtering of 263 input records down to 49 matching records.

## Review & Testing Checklist for Human

- [ ] **Verify end-to-end pipeline execution**: Run `cd src/etl && python run_pipeline.py` and confirm no errors
- [ ] **Validate filtered output**: Check that `src/outputfile/factbook300/part-*.csv` contains only records with Area < 300 and no records >= 300
- [ ] **Test breaking change impact**: Ensure the default change from `local_test3.json` to `test51.json` doesn't break existing workflows that depend on `run_pipeline.py` without arguments
- [ ] **Verify file path resolution**: Confirm relative paths in JSON (`../data/factbook.csv`, `../outputfile/factbook300`) resolve correctly when executed from different directories

### Notes
- Pipeline follows existing patterns from `local_test3.json` and uses standard component types (INPUTFILE, Filter, OUTPUTFILE)
- Filter uses Spark SQL syntax `"Area < 300"` which should work with numeric Area column in factbook.csv
- Output directory will be created automatically by Spark with standard partitioned CSV format

**Link to Devin run**: https://app.devin.ai/sessions/64881843542d40f1b207c6d4c5dccae8  
**Requested by**: parvez.shaikh@ltimindtree.com (@ltibfspoc)